### PR TITLE
fix: useAppState type error

### DIFF
--- a/Modules/@babylonjs/react-native/NativeEngineHook.ts
+++ b/Modules/@babylonjs/react-native/NativeEngineHook.ts
@@ -35,12 +35,13 @@ function useAppState(): string {
         };
 
         const appStateListener = AppState.addEventListener("change", onAppStateChanged);
+        // Asserting the type to prevent TS type errors on older RN versions
+        const removeListener = appStateListener?.["remove"] as undefined | Function;
 
         return () => {
-            if (!!appStateListener?.remove) {
-                appStateListener.remove();
-            }
-            else {
+            if (!!removeListener) {
+                removeListener();
+            } else {
                 AppState.removeEventListener("change", onAppStateChanged);
             }
         };


### PR DESCRIPTION
**Describe the change**

Assert the type of AppState listener "remove" method to prevent TS type errors on older RN versions